### PR TITLE
Remove sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ ruby '2.4.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.2'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -224,12 +223,14 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webpacker
 
+RUBY VERSION
+   ruby 2.4.0p0
+
 BUNDLED WITH
-   1.14.6
+   1.15.3


### PR DESCRIPTION
We have already removed all dependancies for active_record and active_model so we dont need this gem.